### PR TITLE
Implemented horizontal padding

### DIFF
--- a/MaterialTextField/MFTextField.h
+++ b/MaterialTextField/MFTextField.h
@@ -85,6 +85,6 @@ IB_DESIGNABLE
 /**
  * The vertical padding between the underline and the error label.
  */
-@property (nonatomic) IBInspectable CGFloat errorPadding;
+@property (nonatomic) IBInspectable CGSize errorPadding;
 
 @end


### PR DESCRIPTION
I have implemented horizontal padding for the textPadding & errorPadding properties. Error labels still wrap to multiple lines properly, and the horizontal constraints update automatically when either textPadding or errorPadding is changed. 